### PR TITLE
Fixed the error found by Jan

### DIFF
--- a/recommerce/rl/training_scenario.py
+++ b/recommerce/rl/training_scenario.py
@@ -128,7 +128,8 @@ def train_from_config():
 			competitor_list.append(
 				competitor['agent_class'](config=config_hyperparameter, fixed_price=competitor['argument'], name=competitor['name']))
 		else:
-			competitor_list.append(competitor['agent_class'](config=config_hyperparameter,  name=competitor['name']))
+			competitor_list.append(competitor['agent_class'](config=config_hyperparameter, name=competitor['name']))
+
 	run_training_session(
 		config_hyperparameter=config_hyperparameter,
 		marketplace=config.marketplace,


### PR DESCRIPTION
If a training with multiple competitors with the config was started, the second agent was not initialised with a config. this made the training fail. 