### PR TITLE
Insert a missing strip

### DIFF
--- a/docker/app.py
+++ b/docker/app.py
@@ -286,6 +286,6 @@ if __name__ == '__main__':
 	uvicorn.run('app:app',
 		host='0.0.0.0',
 		port=8000,
-		# log_config='./log_api.ini',
+		log_config='./log_api.ini',
 		ssl_keyfile='/etc/sslzertifikat/api_cert.key',
 		ssl_certfile='/etc/sslzertifikat/api_cert.crt')


### PR DESCRIPTION
somehow the webserver has not been authorized to access the api, reason was a missing `strip()`